### PR TITLE
Fix behaviour that occurs when you translate your models after you define a STI child 

### DIFF
--- a/lib/globalize/active_record.rb
+++ b/lib/globalize/active_record.rb
@@ -46,8 +46,11 @@ module Globalize
 
         class_inheritable_accessor :translation_class, :translated_attribute_names
         class_inheritable_writer :required_attributes
-        self.translation_class = ActiveRecord.build_translation_class(self, options)
-        self.translated_attribute_names = attr_names.map(&:to_sym)
+        
+        (subclasses_of(self) + [self]).each do |klass|
+          klass.translation_class = ActiveRecord.build_translation_class(self, options)
+          klass.translated_attribute_names = attr_names.map(&:to_sym)
+        end
 
         include InstanceMethods
         extend  ClassMethods, Migration

--- a/test/active_record/sti_translated_test.rb
+++ b/test/active_record/sti_translated_test.rb
@@ -46,4 +46,16 @@ class StiTranslatedTest < ActiveSupport::TestCase
     I18n.locale = 'he-IL'
     assert_equal 'baz', child.content
   end
+  
+  test "works when STI class is defined before globalize is applied" do
+    child = EarlyChild.create :content => 'foo'
+    I18n.locale = 'de-DE'
+    child.content = 'bar'
+    child.save
+    I18n.locale = 'en-US'
+    child = EarlyChild.first
+    assert_equal 'foo', child.content
+    I18n.locale = 'de-DE'
+    assert_equal 'bar', child.content
+  end
 end

--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -18,6 +18,12 @@ class Blog < ActiveRecord::Base
 end
 
 class Parent < ActiveRecord::Base
+end
+
+class EarlyChild < Parent
+end
+
+class Parent < ActiveRecord::Base
   translates :content
 end
 


### PR DESCRIPTION
When you would define an ActiveRecord model and children, and then globalize the main model, the descendants won't work globalized. (See test)
