### PR TITLE
Fix bug with Globalize::ActiveRecord#attributes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,14 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Default: run unit tests.'
 task :default => :test
 
 desc 'Test the globalize2 plugin.'
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.pattern = 'test/**/*_test.rb'
+  t.libs << "test"
+  t.test_files = FileList['test/**/*_test.rb']
   t.verbose = true
 end
 

--- a/lib/globalize/active_record.rb
+++ b/lib/globalize/active_record.rb
@@ -54,7 +54,7 @@ module Globalize
 
         after_save :save_translations!
         has_many :translations, :class_name  => translation_class.name,
-                                :foreign_key => class_name.foreign_key,
+                                :foreign_key => self.name.foreign_key,
                                 :dependent   => :delete_all,
                                 :extend      => HasManyExtensions
 

--- a/lib/globalize/active_record.rb
+++ b/lib/globalize/active_record.rb
@@ -22,7 +22,7 @@ module Globalize
 
         klass.class_eval do
           set_table_name(options[:table_name])
-          belongs_to target.name.underscore.gsub('/', '_')
+          belongs_to target.base_class.name.underscore.gsub('/', '_')
           def locale; read_attribute(:locale).to_sym; end
           def locale=(locale); write_attribute(:locale, locale.to_s); end
         end
@@ -54,7 +54,7 @@ module Globalize
 
         after_save :save_translations!
         has_many :translations, :class_name  => translation_class.name,
-                                :foreign_key => self.name.foreign_key,
+                                :foreign_key => self.base_class.name.foreign_key,
                                 :dependent   => :delete_all,
                                 :extend      => HasManyExtensions
 

--- a/lib/globalize/active_record.rb
+++ b/lib/globalize/active_record.rb
@@ -156,8 +156,11 @@ module Globalize
 
       def attributes
         self.attribute_names.inject({}) do |attrs, name|
-          attrs[name] = read_attribute(name) ||
-            (globalize.fetch(I18n.locale, name) rescue nil)
+          if @attributes.include? name.to_s
+            attrs[name] = read_attribute(name)
+          else
+            attrs[name] = (globalize.fetch(I18n.locale, name) rescue nil)
+          end
           attrs
         end
       end
@@ -196,10 +199,10 @@ module Globalize
         end
       end
 
-      def reload(options = nil)
+      def reload(*args)
         translated_attribute_names.each { |name| @attributes.delete(name.to_s) }
         globalize.reset
-        super(options)
+        super(*args)
       end
 
       protected

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -458,6 +458,7 @@ class ActiveRecordTest < ActiveSupport::TestCase
     assert Post.last.to_xml =~ /subject/
     assert Post.last.to_xml =~ /content/
   end
+
 end
 
 # TODO error checking for fields that exist in main table, don't exist in

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -321,9 +321,9 @@ class ActiveRecordTest < ActiveSupport::TestCase
     post.set_translations options
     post.reload
 
-    assert ["bar2", "bar2"], [post.subject, post.content]
+    assert_equal ["bar2", "bar2"], [post.subject, post.content]
     Post.locale = :de
-    assert ["foo2", "foo2"], [post.subject, post.content]
+    assert_equal ["foo2", "foo2"], [post.subject, post.content]
   end
 
   test "setting only one translation with set_translations" do
@@ -336,9 +336,9 @@ class ActiveRecordTest < ActiveSupport::TestCase
     post.set_translations options
     post.reload
 
-    assert ["bar2", "bar2"], [post.subject, post.content]
+    assert_equal ["bar2", "bar2"], [post.subject, post.content]
     Post.locale = :de
-    assert ["foo1", "foo1"], [post.subject, post.content]
+    assert_equal ["foo1", "foo1"], [post.subject, post.content]
   end
 
   test "setting only selected attributes with set_translations" do
@@ -351,9 +351,9 @@ class ActiveRecordTest < ActiveSupport::TestCase
     post.set_translations options
     post.reload
 
-    assert ["bar2", "bar1"], [post.subject, post.content]
+    assert_equal ["bar2", "bar1"], [post.subject, post.content]
     Post.locale = :de
-    assert ["foo1", "foo2"], [post.subject, post.content]
+    assert_equal ["foo1", "foo2"], [post.subject, post.content]
   end
 
   test "setting invalid attributes raises ArgumentError" do
@@ -475,7 +475,7 @@ class ActiveRecordTest < ActiveSupport::TestCase
     created = Post.create :subject => "foo", :content => "bar", :label => "dummy"
     found = Post.find_by_subject_and_label("foo", "dummy")
 
-    assert created, found
+    assert_equal created, found
   end
 
   test "dynamic find all matcher on multiple attributes" do
@@ -484,7 +484,7 @@ class ActiveRecordTest < ActiveSupport::TestCase
 
     found = Post.find_all_by_subject_and_label("foo", "dummy")
 
-    assert [created1, created2], found
+    assert_equal [created1, created2], found
   end
 
   test "dynamic find last matcher on multiple attributes" do
@@ -493,14 +493,14 @@ class ActiveRecordTest < ActiveSupport::TestCase
 
     found = Post.find_last_by_subject_and_label("foo", "dummy")
 
-    assert created2, found
+    assert_equal created2, found
   end
 
   test "dynamic find first matcher with too few values" do
     created = Post.create :subject => "foo", :content => "bar", :label => "dummy"
     found = Post.find_by_subject_and_label("foo")
 
-    assert created, found
+    assert_equal created, found
   end
 
   test "dynamic find first matcher with bang" do

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
 
   create_table :posts, :force => true do |t|
     t.references :blog
+    t.string :label
   end
 
   create_table :post_translations, :force => true do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,7 +41,7 @@ end
 module ActiveRecord
   module ConnectionAdapters
     class AbstractAdapter
-      def index_exists?(table_name, column_name)
+      def index_exists?(table_name, column_name, options = {})
         indexes(table_name).any? { |index| index.name == index_name(table_name, column_name) }
       end
     end


### PR DESCRIPTION
The current implementation causes attributes to be fetched from globalize's cache instead of the model's attributes.  When a value for an attribute is false, then the cache is checked causing a return of nil instead of false.  The end result can cause validation errors when inserting records into the database.  This patch first checks to see whether the attribute is set on the model.  If it is set, the value is returned, otherwise it returns the value from globalize's attribute cache.

Globalize::ActiveRecord#reload is also patched to play nicely with alias_method_chain from other plugins.
